### PR TITLE
Makefile rework

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,11 @@
 # Apprentice binary
 
 CC = gcc
-CFLAGS = -std=c99 -g -Wall -Wextra -Werror
-LDFLAGS = -lm -lmagic
-HEADER_FILES = src
-C_SOURCE_FILES = src/apprentice.c
-OBJECT_FILES = $(C_SOURCE_FILES:.c=.o)
-EXECUTABLE_DIRECTORY = priv
-EXECUTABLE = $(EXECUTABLE_DIRECTORY)/apprentice
+CFLAGS = -std=c99 -g -Wall -Werror
+LDLIBS = -lm -lmagic
+BEAM_FILES = _build/
+PRIV = priv/
+RM = rm -Rf
 
 # Unit test custom magic file
 
@@ -16,20 +14,9 @@ TEST_DIRECTORY = test
 TARGET_MAGIC = $(TEST_DIRECTORY)/elixir.mgc
 SOURCE_MAGIC = $(TEST_DIRECTORY)/elixir
 
-# Target
-
-all: $(EXECUTABLE) $(TARGET_MAGIC)
-
-# Compile
-
-$(EXECUTABLE): $(OBJECT_FILES) $(EXECUTABLE_DIRECTORY)
-	$(CC) $(OBJECT_FILES) -o $@ $(LDFLAGS)
-
-$(EXECUTABLE_DIRECTORY):
-	mkdir -p $(EXECUTABLE_DIRECTORY)
-
-.o:
-	$(CC) $(CFLAGS) $< -o $@
+priv/apprentice: src/apprentice.c
+	mkdir -p priv
+	$(CC) $(CFLAGS) $(LDLIBS) $^ -o $@
 
 # Test case
 
@@ -37,4 +24,6 @@ $(TARGET_MAGIC): $(SOURCE_MAGIC)
 	cd $(TEST_DIRECTORY); $(MAGIC) -C -m elixir
 
 clean:
-	rm -f $(EXECUTABLE) $(OBJECT_FILES) $(BEAM_FILES)
+	$(RM) $(PRIV) $(BEAM_FILES)
+
+.PHONY: clean


### PR DESCRIPTION
This commit simplifies and fixes several quirks of the Makefile:

* LDLIBS is now used instead of LDFLAGS
* Only one step is now necessary to compile the binary
* `clean` is now marked as a PHONY rule