### PR TITLE
Fixed "magic.h not found" error on Mac OS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC = gcc
 CFLAGS = -std=c99 -g -Wall -Wextra -Werror
-LDLIBS = -lm `pkg-config --libs libmagic 2>/dev/null || echo "-lmagic"`
+LDLIBS = -lm `pkg-config --cflags --libs libmagic 2>/dev/null || echo "-lmagic"`
 PRIV = priv/
 RM = rm -Rf
 


### PR DESCRIPTION
* Added --cflags for libmagic magic lookup via pkg-config